### PR TITLE
DR-800 Add dependabot branch to test build workflow trigger

### DIFF
--- a/.github/workflows/test-build-and-deploy.yaml
+++ b/.github/workflows/test-build-and-deploy.yaml
@@ -5,9 +5,12 @@ on:
     branches:
       - main
       - 'task/*'
+  pull_request:
+    types: [ labeled ]
 
 jobs:
   metadata:
+    if: ( ${{ github.event.label.name == 'Test Ready' && startswith(github.head_ref, 'dependabot/') }} ) || ( ${{ github.event_name == 'push' }} && ( ${{ startswith(github.ref_name, 'task/') || startswith(github.ref_name, 'main') }} ) )
     name: "Get Metadata"
     uses: ./.github/workflows/metadata.yaml
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adding dependabot branch to test-build-and-deploy.yaml trigger as "Test Ready for Test Label" workflow is broke due to dependency on pipeline-deploy-app-develop building the artefact. 

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
