### PR TITLE
Task/dr 1164 fix python code coverage report upload

### DIFF
--- a/.github/workflows/build-application.yaml
+++ b/.github/workflows/build-application.yaml
@@ -74,25 +74,6 @@ jobs:
           service: ${{ matrix.service }}
           directory: ${{ inputs.directory }}
 
-      - name: "Run python unit test"
-        uses: NHSDigital/uec-dos-management/.github/actions/unit-test-python@latest
-        with:
-          aws_region: ${{ vars.AWS_REGION }}
-          python_version: ${{ inputs.python_version }}
-
-      - name: "Archive python code coverage results"
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-code-coverage-report
-          path: coverage.xml
-
-      - name: "Perform static analysis"
-        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@latest
-        with:
-          sonar_organisation_key: ${{ vars.SONAR_ORGANISATION_KEY }}
-          sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}
-          sonar_token: ${{ secrets.SONAR_TOKEN }}
-
       - name: "Upload service to S3 bucket"
         uses: NHSDigital/uec-dos-management/.github/actions/push-artefact@latest
         with:

--- a/.github/workflows/build-react-app.yaml
+++ b/.github/workflows/build-react-app.yaml
@@ -103,7 +103,7 @@ jobs:
           path: ${{ inputs.code_directory }}/coverage/lcov.info
 
       - name: Perform static analysis
-        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@task/DR-1164_Fix_python_code_coverage_report_upload
+        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@latest
         with:
           sonar_organisation_key: ${{ vars.SONAR_ORGANISATION_KEY }}
           sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}

--- a/.github/workflows/build-react-app.yaml
+++ b/.github/workflows/build-react-app.yaml
@@ -103,7 +103,7 @@ jobs:
           path: ${{ inputs.code_directory }}/coverage/lcov.info
 
       - name: Perform static analysis
-        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@latest
+        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@task/DR-1164_Fix_python_code_coverage_report_upload
         with:
           sonar_organisation_key: ${{ vars.SONAR_ORGANISATION_KEY }}
           sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}

--- a/.github/workflows/pipeline-deploy-app-develop.yaml
+++ b/.github/workflows/pipeline-deploy-app-develop.yaml
@@ -59,11 +59,25 @@ jobs:
       stacks: '["github-runner", "terraform_management"]'
     secrets: inherit
 
+  unit-tests:
+    if: ${{ github.event_name == 'push' }}
+    name: "Python Unit Tests"
+    needs:
+      [
+        metadata,
+        quality-checks,
+      ]
+    uses: NHSDigital/uec-dos-management/.github/workflows/unit-test.yaml@task/DR-1172_Correctly_align_terraform_config
+    with:
+      env: mgmt
+    secrets: inherit
+
   build-python-application:
     name: "Build Python Application"
     needs:
       [
         metadata,
+        unit-tests,
       ]
     if: ${{ github.event_name == 'push' }}
     uses: ./.github/workflows/build-application.yaml

--- a/.github/workflows/pipeline-deploy-app-develop.yaml
+++ b/.github/workflows/pipeline-deploy-app-develop.yaml
@@ -67,7 +67,7 @@ jobs:
         metadata,
         quality-checks,
       ]
-    uses: NHSDigital/uec-dos-management/.github/workflows/unit-test.yaml@task/DR-1172_Correctly_align_terraform_config
+    uses: NHSDigital/uec-dos-management/.github/workflows/unit-test.yaml@task/DR-1164_Fix_python_code_coverage_report_upload
     with:
       env: mgmt
     secrets: inherit

--- a/.github/workflows/pipeline-deploy-app-develop.yaml
+++ b/.github/workflows/pipeline-deploy-app-develop.yaml
@@ -67,7 +67,7 @@ jobs:
         metadata,
         quality-checks,
       ]
-    uses: NHSDigital/uec-dos-management/.github/workflows/unit-test.yaml@task/DR-1164_Fix_python_code_coverage_report_upload
+    uses: NHSDigital/uec-dos-management/.github/workflows/unit-test.yaml@latest
     with:
       env: mgmt
     secrets: inherit

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -48,7 +48,7 @@ jobs:
           name: "python-code-coverage-report"
           path: coverage.xml
       - name: Perform static analysis
-        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@task/DR-1164_Fix_python_code_coverage_report_upload
+        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@latest
         with:
           sonar_organisation_key: ${{ vars.SONAR_ORGANISATION_KEY }}
           sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -42,8 +42,13 @@ jobs:
         with:
           aws_region: ${{ vars.AWS_REGION }}
           python_version: ${{ inputs.python_version }}
+      - name: "Archive python code coverage results"
+        uses: actions/upload-artifact@v4
+        with:
+          name: "python-code-coverage-report"
+          path: coverage.xml
       - name: Perform static analysis
-        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@latest
+        uses: NHSDigital/uec-dos-management/.github/actions/perform-static-analysis@task/DR-1164_Fix_python_code_coverage_report_upload
         with:
           sonar_organisation_key: ${{ vars.SONAR_ORGANISATION_KEY }}
           sonar_project_key: ${{ vars.SONAR_PROJECT_KEY }}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Due to multiple reports attempting to be uploaded simultaneously, the uec-dos-service-management has encountered issues. Previously, unit tests were adjusted to perform static checks only once, rather than for each Python application. To address this, we are adding the unit test job back into the application deployment workflow.

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
